### PR TITLE
XaccQuantum: Add utility methods for runtime

### DIFF
--- a/src/qirxacc/XaccQuantum.cc
+++ b/src/qirxacc/XaccQuantum.cc
@@ -299,6 +299,39 @@ void XaccQuantum::z(Qubit q)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Get runtime qubit corresponding to a runtime result.
+ */
+Qubit XaccQuantum::result_to_qubit(Result r)
+{
+    QIREE_EXPECT(r.value < this->num_results());
+    return result_to_qubit_[r.value];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Obtain measured qubit values, accounting for endianness.
+ *
+ * Wrapper for \c xacc::AcceleratorBuffer::getMarginalCounts()
+ */
+std::map<std::string, int>
+XaccQuantum::get_marginal_counts(std::vector<Qubit> const& qubits)
+{
+    using BitOrder = xacc::AcceleratorBuffer::BitOrder;
+
+    std::vector<int> indices;
+    indices.reserve(qubits.size());
+    for (Qubit const& qubit : qubits)
+    {
+        QIREE_EXPECT(qubit.value < this->num_qubits());
+        indices.push_back(static_cast<int>(qubit.value));
+    }
+
+    return buffer_->getMarginalCounts(
+        indices, endian_ == Endianness::little ? BitOrder::LSB : BitOrder::MSB);
+}
+
+//---------------------------------------------------------------------------//
 // PRIVATE FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/qirxacc/XaccQuantum.cc
+++ b/src/qirxacc/XaccQuantum.cc
@@ -310,9 +310,10 @@ Qubit XaccQuantum::result_to_qubit(Result r)
 
 //---------------------------------------------------------------------------//
 /*!
- * Obtain measured qubit values, accounting for endianness.
- *
- * Wrapper for \c xacc::AcceleratorBuffer::getMarginalCounts()
+ * Return marginal measurement statistics for the subset of qubits passed. A
+ * measurement bit at index i of a measurement bitstring corresponds to the
+ * qubit at index i of the input vector. The length of each measurement
+ * bitstring is exactly the length of the input vector of qubits.
  */
 std::map<std::string, int>
 XaccQuantum::get_marginal_counts(std::vector<Qubit> const& qubits)

--- a/src/qirxacc/XaccQuantum.hh
+++ b/src/qirxacc/XaccQuantum.hh
@@ -76,6 +76,7 @@ class XaccQuantum final : virtual public QuantumNotImpl,
     //! \name Runtime interface
     // Initialize the execution environment, resetting qubits
     void initialize(OptionalCString env) override;
+
     // Execute the circuit and read outputs
     void array_record_output(size_type, OptionalCString tag) final;
 
@@ -115,8 +116,7 @@ class XaccQuantum final : virtual public QuantumNotImpl,
     // Get runtime qubit corresponding to a runtime result
     Qubit result_to_qubit(Result);
 
-    // Wrapper for xacc::AcceleratorBuffer::getMarginalCounts() that handles
-    // endianness
+    // Return marginal statistics for a subset of qubits
     std::map<std::string, int>
     get_marginal_counts(std::vector<Qubit> const& qubits);
     //!@}

--- a/src/qirxacc/XaccQuantum.hh
+++ b/src/qirxacc/XaccQuantum.hh
@@ -76,7 +76,6 @@ class XaccQuantum final : virtual public QuantumNotImpl,
     //! \name Runtime interface
     // Initialize the execution environment, resetting qubits
     void initialize(OptionalCString env) override;
-
     // Execute the circuit and read outputs
     void array_record_output(size_type, OptionalCString tag) final;
 
@@ -109,6 +108,17 @@ class XaccQuantum final : virtual public QuantumNotImpl,
     void x(Qubit) final;
     void y(Qubit) final;
     void z(Qubit) final;
+    //!@}
+
+    //!@{
+    //! \name Utilities for runtime
+    // Get runtime qubit corresponding to a runtime result
+    Qubit result_to_qubit(Result);
+
+    // Wrapper for xacc::AcceleratorBuffer::getMarginalCounts() that handles
+    // endianness
+    std::map<std::string, int>
+    get_marginal_counts(std::vector<Qubit> const& qubits);
     //!@}
 
   private:


### PR DESCRIPTION
These will be useful for separating out the runtime from XACC stuff.

### Testing

Compiles and passes `ctest`