### PR TITLE
Default XACC on for users but off for CI

### DIFF
--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -66,6 +66,7 @@ jobs:
               || format(';-{0};', github.ref_name)}}" \
             -DQIREE_BUILD_TESTS:BOOL=ON \
             -DQIREE_DEBUG:BOOL=ON \
+            -DQIREE_USE_XACC:BOOL=OFF \
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/install" \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endmacro()
 # Components
 option(QIREE_BUILD_DOCS "Build QIR-EE documentation" OFF)
 option(QIREE_BUILD_TESTS "Build QIR-EE unit tests" ON)
-option(QIREE_USE_XACC "Build XACC interface" OFF)
+option(QIREE_USE_XACC "Build XACC interface" ON)
 qiree_set_default(BUILD_TESTING ${QIREE_BUILD_TESTS})
 
 # Assertion handling


### PR DESCRIPTION
This tells users that they need XACC by default for full functionality, but it leaves XACC disabled inside the CI so that we can do full testing without an XACC build.