### PR TITLE
Create separate runtime for per-tuple measurements

### DIFF
--- a/src/qirxacc/CMakeLists.txt
+++ b/src/qirxacc/CMakeLists.txt
@@ -6,6 +6,8 @@
 
 qiree_add_library(qirxacc
   XaccQuantum.cc
+  XaccDefaultRuntime.cc
+  XaccTupleRuntime.cc
 )
 target_link_libraries(qirxacc
   PUBLIC QIREE::qiree

--- a/src/qirxacc/XaccDefaultRuntime.cc
+++ b/src/qirxacc/XaccDefaultRuntime.cc
@@ -1,0 +1,79 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other QIR-EE developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//---------------------------------------------------------------------------//
+//! \file qirxacc/XaccDefaultRuntime.cc
+//---------------------------------------------------------------------------//
+#include "XaccDefaultRuntime.hh"
+
+#include "qiree/Assert.hh"
+
+namespace qiree
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Initialize the execution environment, resetting qubits.
+ */
+void XaccDefaultRuntime::initialize(OptionalCString env)
+{
+    if (env)
+    {
+        output_ << "Argument to initialize: " << env << std::endl;
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Execute circuit and mark the following N results as being part of an array
+ * named tag
+ */
+void XaccDefaultRuntime::array_record_output(size_type s, OptionalCString tag)
+{
+    this->execute_if_needed();
+    output_ << "array " << (tag ? tag : "<null>") << " length " << s
+            << std::endl;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Execute circuit and mark the following N results as being part of a tuple
+ * named tag.
+ */
+void XaccDefaultRuntime::tuple_record_output(size_type s, OptionalCString tag)
+{
+    this->execute_if_needed();
+    output_ << "tuple " << (tag ? tag : "<null>") << " length " << s
+            << std::endl;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Execute circuit and report a single measurement result
+ */
+void XaccDefaultRuntime::result_record_output(Result r, OptionalCString tag)
+{
+    this->execute_if_needed();
+    Qubit q = xacc_.result_to_qubit(r);
+
+    // Get a map of string ("0" and "1" ???) -> int
+    auto counts = xacc_.get_marginal_counts({q});
+
+    // Print the result
+    output_ << "qubit " << q.value << " experiment " << (tag ? tag : "<null>")
+            << ": {0: " << counts["0"] << ", 1: " << counts["1"] << '}'
+            << std::endl;
+}
+
+//---------------------------------------------------------------------------//
+// PRIVATE FUNCTIONS
+//---------------------------------------------------------------------------//
+
+void XaccDefaultRuntime::execute_if_needed()
+{
+    if (xacc_.execute_if_needed() && print_accelbuf_)
+    {
+        xacc_.print_accelbuf();
+    }
+}
+}  // namespace qiree

--- a/src/qirxacc/XaccDefaultRuntime.hh
+++ b/src/qirxacc/XaccDefaultRuntime.hh
@@ -1,0 +1,76 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other QIR-EE developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//---------------------------------------------------------------------------//
+//! \file qirxacc/XaccDefaultRuntime.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "qiree/RuntimeInterface.hh"
+#include "qirxacc/XaccQuantum.hh"
+
+namespace qiree
+{
+class XaccQuantum;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Print per-qubit measurement statistics.
+ *
+ * (Compare with \ref XaccTupleRuntime.)
+ *
+ * Example:
+ * \code
+ * tuple ret length 2
+ * qubit 0 experiment <null>: {0: 509, 1: 515}
+ * qubit 1 experiment <null>: {0: 509, 1: 515}
+ * \endcode
+ */
+class XaccDefaultRuntime final : virtual public RuntimeInterface
+{
+  public:
+    // Construct with XACC quantum runtime and options
+    inline XaccDefaultRuntime(std::ostream& output,
+                              XaccQuantum& xacc,
+                              bool print_accelbuf);
+
+    //!@{
+    //! \name Runtime interface
+    // Initialize the execution environment, resetting qubits
+    void initialize(OptionalCString env) override;
+
+    //! Mark the following N results as being part of an array named tag
+    void array_record_output(size_type, OptionalCString tag) final;
+
+    //! Mark the following N results as being part of a tuple named tag
+    void tuple_record_output(size_type, OptionalCString) final;
+
+    // Save one result
+    void result_record_output(Result result, OptionalCString tag) final;
+    //!@}
+
+  private:
+    std::ostream& output_;
+    XaccQuantum& xacc_;
+    bool const print_accelbuf_;
+
+    void execute_if_needed();
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct an \c XaccDefaultRuntime.
+ *
+ * The \c print_accelbuf argument determines whether the XACC \c
+ * AcceleratorBuffer is dumped after execution.
+ */
+XaccDefaultRuntime::XaccDefaultRuntime(std::ostream& output,
+                                       XaccQuantum& xacc,
+                                       bool print_accelbuf = true)
+    : output_(output), xacc_(xacc), print_accelbuf_(print_accelbuf)
+{
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace qiree

--- a/src/qirxacc/XaccQuantum.hh
+++ b/src/qirxacc/XaccQuantum.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <initializer_list>
+#include <map>
 #include <memory>
 #include <ostream>
 #include <vector>
@@ -15,7 +16,6 @@
 #include "qiree/Macros.hh"
 #include "qiree/QuantumNotImpl.hh"
 #include "qiree/RuntimeInterface.hh"
-#include <map>
 #include "qiree/Types.hh"
 
 namespace xacc
@@ -28,12 +28,12 @@ class CompositeInstruction;
 
 namespace qiree
 {
+
 //---------------------------------------------------------------------------//
 /*!
  * Translate instructions from QIR to XACC and execute them on read.
  */
-class XaccQuantum final : virtual public QuantumNotImpl,
-                          virtual public RuntimeInterface
+class XaccQuantum final : virtual public QuantumNotImpl
 {
   public:
     // Call XACC initialize explicitly with args
@@ -74,21 +74,6 @@ class XaccQuantum final : virtual public QuantumNotImpl,
     //!@}
 
     //!@{
-    //! \name Runtime interface
-    // Initialize the execution environment, resetting qubits
-    void initialize(OptionalCString env) override;
-
-    // Execute the circuit and read outputs
-    void array_record_output(size_type, OptionalCString tag) final;
-
-    // Save one result
-    void result_record_output(Result result, OptionalCString tag) final;
-
-    // No one uses tuples??
-    void tuple_record_output(size_type, OptionalCString) final;
-    //!@}
-
-    //!@{
     //! \name Circuit construction
     void ccx(Qubit, Qubit) final;
     void ccnot(Qubit, Qubit, Qubit);  // TODO: not in examples or qir runner
@@ -120,6 +105,13 @@ class XaccQuantum final : virtual public QuantumNotImpl,
     // Return marginal statistics for a subset of qubits
     std::map<std::string, int>
     get_marginal_counts(std::vector<Qubit> const& qubits);
+
+    // Run the circuit on the accelerator if we have not already. Returns true
+    // if the circuit was executed.
+    bool execute_if_needed();
+
+    // Print the \c xacc::AcceleratorBuffer
+    void print_accelbuf();
     //!@}
 
   private:
@@ -132,6 +124,7 @@ class XaccQuantum final : virtual public QuantumNotImpl,
 
     //// DATA ////
 
+    bool executed_{false};
     size_type num_qubits_{};
     std::vector<Qubit> result_to_qubit_;
     Endianness endian_;

--- a/src/qirxacc/XaccTupleRuntime.cc
+++ b/src/qirxacc/XaccTupleRuntime.cc
@@ -1,0 +1,139 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other QIR-EE developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//---------------------------------------------------------------------------//
+//! \file qirxacc/XaccTupleRuntime.cc
+//---------------------------------------------------------------------------//
+#include "XaccTupleRuntime.hh"
+
+#include "qiree/Assert.hh"
+
+namespace qiree
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construct an \c XaccTupleRuntime.
+ *
+ * The \c print_accelbuf argument determines whether the XACC \c
+ * AcceleratorBuffer is dumped after execution.
+ */
+XaccTupleRuntime::XaccTupleRuntime(std::ostream& output,
+                                   XaccQuantum& xacc,
+                                   bool print_accelbuf)
+    : output_(output)
+    , xacc_(xacc)
+    , print_accelbuf_(print_accelbuf)
+    , valid_(false)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Initialize the execution environment, resetting qubits.
+ */
+void XaccTupleRuntime::initialize(OptionalCString env)
+{
+    if (env)
+    {
+        output_ << "Argument to initialize: " << env << std::endl;
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Execute circuit and mark the following N results as being part of an array
+ * named tag.
+ */
+void XaccTupleRuntime::array_record_output(size_type s, OptionalCString tag)
+{
+    execute_if_needed();
+    start_tracking(GroupingType::array, tag, s);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Execute circuit and mark the following N results as being part of a tuple
+ * named tag.
+ */
+void XaccTupleRuntime::tuple_record_output(size_type s, OptionalCString tag)
+{
+    execute_if_needed();
+    start_tracking(GroupingType::tuple, tag, s);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Execute circuit and report a single measurement result.
+ */
+void XaccTupleRuntime::result_record_output(Result r, OptionalCString tag)
+{
+    execute_if_needed();
+    Qubit q = xacc_.result_to_qubit(r);
+    push_result(q);
+}
+
+//---------------------------------------------------------------------------//
+// PRIVATE FUNCTIONS
+//---------------------------------------------------------------------------//
+
+void XaccTupleRuntime::execute_if_needed()
+{
+    if (xacc_.execute_if_needed() && print_accelbuf_)
+    {
+        xacc_.print_accelbuf();
+    }
+}
+
+void XaccTupleRuntime::start_tracking(GroupingType type,
+                                      std::string tag,
+                                      size_type num_results)
+{
+    QIREE_EXPECT(!valid_);
+    valid_ = true;
+    type_ = type_;
+    tag_ = tag;
+    num_results_ = num_results;
+    qubits_.clear();
+
+    if (!num_results_)
+    {
+        // Edge case
+        print_header(0);
+        valid_ = false;
+    }
+}
+
+void XaccTupleRuntime::push_result(Qubit q)
+{
+    QIREE_EXPECT(valid_);
+    QIREE_EXPECT(qubits_.size() < num_results_);
+    qubits_.push_back(q);
+    if (qubits_.size() == num_results_)
+    {
+        finish_tuple();
+    }
+}
+
+void XaccTupleRuntime::print_header(size_type num_distinct)
+{
+    auto name = this->grouping_name();
+    output_ << name << " " << tag_ << " length " << qubits_.size()
+            << " distinct results " << num_distinct << std::endl;
+}
+
+void XaccTupleRuntime::finish_tuple()
+{
+    auto counts = xacc_.get_marginal_counts(qubits_);
+    print_header(counts.size());
+    auto name = this->grouping_name();
+    for (auto& [bits, count] : counts)
+    {
+        output_ << name << " " << tag_ << " result " << bits << " count "
+                << count << std::endl;
+    }
+    valid_ = false;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace qiree

--- a/src/qirxacc/XaccTupleRuntime.hh
+++ b/src/qirxacc/XaccTupleRuntime.hh
@@ -1,0 +1,86 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other QIR-EE developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//---------------------------------------------------------------------------//
+//! \file qirxacc/XaccTupleRuntime.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "qirxacc/XaccQuantum.hh"
+
+namespace qiree
+{
+class XaccQuantum;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Print per-tuple (or per-array) measurement statistics.
+ *
+ * (Compare with \ref XaccDefaultRuntime.)
+ *
+ * Example:
+ * \code
+ * tuple ret length 2 distinct results 2
+ * tuple ret result 00 count 512
+ * tuple ret result 11 count 512
+ * \endcode
+ */
+class XaccTupleRuntime final : virtual public RuntimeInterface
+{
+  public:
+    // Construct with XACC quantum runtime and options
+    XaccTupleRuntime(std::ostream& output,
+                     XaccQuantum& xacc,
+                     bool print_accelbuf);
+
+    //!@{
+    //! \name Runtime interface
+    // Initialize the execution environment, resetting qubits
+    void initialize(OptionalCString env) override;
+
+    // Execute circuit and mark the following N results as being part of an
+    // array named tag
+    void array_record_output(size_type, OptionalCString tag) final;
+
+    // Execute circuit and mark the following N results as being part of a
+    // tuple named tag
+    void tuple_record_output(size_type, OptionalCString) final;
+
+    // Execute circuit and report a single measurement result
+    void result_record_output(Result result, OptionalCString tag) final;
+    //!@}
+
+  private:
+    enum class GroupingType
+    {
+        tuple,
+        array,
+    };
+
+    std::ostream& output_;
+    XaccQuantum& xacc_;
+    bool const print_accelbuf_;
+    bool valid_;
+    GroupingType type_;
+    std::string tag_;
+    size_type num_results_;
+    std::vector<Qubit> qubits_;
+
+    void execute_if_needed();
+    void
+    start_tracking(GroupingType type, std::string tag, size_type num_results);
+    void push_result(Qubit q);
+    void print_header(size_type num_distinct);
+    void finish_tuple();
+
+    char const* const grouping_name() const
+    {
+        return type_ == GroupingType::tuple   ? "tuple"
+               : type_ == GroupingType::array ? "array"
+                                              : "grouping";
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace qiree

--- a/test/qirxacc/XaccQuantum.test.cc
+++ b/test/qirxacc/XaccQuantum.test.cc
@@ -11,6 +11,7 @@
 
 #include "qiree/Types.hh"
 #include "qiree_test.hh"
+#include "qirxacc/XaccDefaultRuntime.hh"
 
 namespace qiree
 {
@@ -65,6 +66,7 @@ TEST_F(XaccQuantumTest, sim_rotation)
 
     // Create a simulator that will write to the string stream
     XaccQuantum xacc_sim{os};
+    XaccDefaultRuntime xacc_rt{os, xacc_sim};
 
     // Call functions in the same sequence that rotation.ll would
     xacc_sim.set_up([] {
@@ -77,8 +79,8 @@ TEST_F(XaccQuantumTest, sim_rotation)
     xacc_sim.rx(pi / 6, Q{0});
     xacc_sim.h(Q{0});
     xacc_sim.mz(Q{0}, R{0});
-    xacc_sim.array_record_output(1, "yeehaw");
-    xacc_sim.result_record_output(R{0}, "tag");
+    xacc_rt.array_record_output(1, "yeehaw");
+    xacc_rt.result_record_output(R{0}, "tag");
     xacc_sim.tear_down();
 
     auto result = clean_output(os.str());


### PR DESCRIPTION
Third time's the charm!

(For context for future readers: it is useful to have statistics on a per-tuple level versus a per-qubit level)

### Testing

`ctest` and manual testing with `qir-xacc`:
```
$ build/bin/qir-xacc -i examples/qwerty/bv1101.ll --group-tuples --no-print-accelbuf -a qpp
tuple ret length 4 distinct results 1
tuple ret result 1101 count 1024
tuple discarded length 0 distinct results 0
$ build/bin/qir-xacc -i examples/qwerty/bv1101.ll --group-tuples -a qpp
{
    "AcceleratorBuffer": {
        "name": "qreg_0x5633ea6eb6e0",
        "size": 4,
        "Information": {},
        "Measurements": {
            "1101": 1024
        }
    }
}
tuple ret length 4 distinct results 1
tuple ret result 1101 count 1024
tuple discarded length 0 distinct results 0
$ build/bin/qir-xacc -i examples/qwerty/ghz5.ll --group-tuples --no-print-accelbuf -a qpp
tuple ret length 5 distinct results 2
tuple ret result 00000 count 493
tuple ret result 11111 count 531
tuple discarded length 0 distinct results 0
$ build/bin/qir-xacc -i examples/qwerty/ghz5.ll --no-print-accelbuf -a qpp
tuple ret length 5
qubit 0 experiment <null>: {0: 518, 1: 506}
qubit 1 experiment <null>: {0: 518, 1: 506}
qubit 2 experiment <null>: {0: 518, 1: 506}
qubit 3 experiment <null>: {0: 518, 1: 506}
qubit 4 experiment <null>: {0: 518, 1: 506}
tuple discarded length 0
```

I have not tested Qwerty end-to-end yet because there are 2-3 more PRs needed to upstream all my changes, some of which may take a while. But the (tuple-grouped) output is the same as it expects