### PR TITLE
Add option xacc test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ endmacro()
 option(QIREE_BUILD_DOCS "Build QIR-EE documentation" OFF)
 option(QIREE_BUILD_TESTS "Build QIR-EE unit tests" ON)
 option(QIREE_USE_XACC "Build XACC interface" ON)
+option(QIREE_BUILD_XACC_TESTS "Build XACC tests" OFF)
 qiree_set_default(BUILD_TESTING ${QIREE_BUILD_TESTS})
 
 # Assertion handling

--- a/src/qirxacc/XaccQuantum.hh
+++ b/src/qirxacc/XaccQuantum.hh
@@ -15,6 +15,7 @@
 #include "qiree/Macros.hh"
 #include "qiree/QuantumNotImpl.hh"
 #include "qiree/RuntimeInterface.hh"
+#include <map>
 #include "qiree/Types.hh"
 
 namespace xacc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,7 +50,7 @@ qiree_add_test(qiree Module)
 # QIRXACC TESTS
 #---------------------------------------------------------------------------##
 
-if(QIREE_USE_XACC)
+if(QIREE_USE_XACC AND QIREE_BUILD_XACC_TESTS)
   qiree_add_test(qirxacc XaccQuantum)
 endif()
 


### PR DESCRIPTION
I was having some build issues and these changes address those issues, with an option to turn off XACC build tests (current default is OFF until @ausbin's PR is merged). Also, I added a missing include to `XaccQuantum.hh` but did not modify `.clang-format` (wasn't sure if needed). The build on my end is fine with these changes.