### PR TITLE
Use aer instead of qsim so that tests can pass

### DIFF
--- a/src/qirxacc/XaccQuantum.cc
+++ b/src/qirxacc/XaccQuantum.cc
@@ -65,7 +65,7 @@ XaccQuantum::XaccQuantum(std::ostream& os,
 /*!
  * Construct with simulator.
  */
-XaccQuantum::XaccQuantum(std::ostream& os) : XaccQuantum{os, "qsim", 1} {}
+XaccQuantum::XaccQuantum(std::ostream& os) : XaccQuantum{os, "aer", 1} {}
 
 //---------------------------------------------------------------------------//
 /*!


### PR DESCRIPTION
with xacc minimal build for qiree