### PR TITLE
Readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ doc` (user) or `make doxygen` (developer).
 There are two dependencies for QIR-EE to work properly. Please make sure to
 download and install the most current versions of:
 1. [LLVM](https://releases.llvm.org/) (we have tested versions 14 through 18)
-2. [XACC](https://xacc.readthedocs.io/en/latest/install.html) (currently
-   required for execution in this version of qir-ee)
+2. [XACC](https://github.com/ORNL-QCI/xacc) (repo that is actively 
+   maintained -- not the eclipse one; currently required for execution in 
+   this version of qir-ee; we recommend setting option `-DQIREE_MINIMAL_BUILD=ON`
+   during cmake for a faster build)
 
 ### System Requirements
 
@@ -87,19 +89,21 @@ qee llvm-file-path --flag-name flag-value
    specifies the quantum program (required).
 3. `-a` or `--accelerator` is the name of the quantum accelerator (hardware or
    simulator) that you wish to use (required).
+4. `-s` or `--shots` is the number of shots (optional with default at 1024).
 
    With XACC we have tested: `aer`, `qpp`, `qsim`, `honeywell:H1-1SC`, `honeywell:H1-1E`, `honeywell:H1-1`, `ionq`.
+   Note that the minimal build only includes `aer` and `qpp` for local simulators.
 
 Please refer to the documentation here (add link) for all flag options.
 
 ### Example:
 
 ```
-qee $HOME/qir-xir/examples/bell.ll --accelerator qsim
+qee $HOME/qir-xir/examples/bell.ll --accelerator qpp
 ```
 
 This command will execute the quantum Bell circuit described in `bell.ll` the
-(default) 1024 times using the "qsim" accelerator.
+(default) 1024 times using the "qpp" accelerator.
 
 ## Understanding the Results
 

--- a/app/qir-xacc.cc
+++ b/app/qir-xacc.cc
@@ -80,15 +80,6 @@ int main(int argc, char* argv[])
     auto* nshot_opt
         = app.add_option("-s,--shots", num_shots, "Number of shots");
     nshot_opt->capture_default_str();
-    /*
-    app.add_flag("--print-accelbuf,!--no-print-accelbuf",
-                 print_accelbuf,
-                 "Print XACC AcceleratorBuffer");
-    app.add_flag("--group-tuples,!--no-group-tuples",
-                 group_tuples,
-                 "Print per-tuple measurement statistics rather than "
-                 "per-qubit");
-    */
 
     CLI11_PARSE(app, argc, argv);
 

--- a/app/qir-xacc.cc
+++ b/app/qir-xacc.cc
@@ -80,6 +80,7 @@ int main(int argc, char* argv[])
     auto* nshot_opt
         = app.add_option("-s,--shots", num_shots, "Number of shots");
     nshot_opt->capture_default_str();
+    /*
     app.add_flag("--print-accelbuf,!--no-print-accelbuf",
                  print_accelbuf,
                  "Print XACC AcceleratorBuffer");
@@ -87,6 +88,7 @@ int main(int argc, char* argv[])
                  group_tuples,
                  "Print per-tuple measurement statistics rather than "
                  "per-qubit");
+    */
 
     CLI11_PARSE(app, argc, argv);
 

--- a/examples/qwerty/bell.ll
+++ b/examples/qwerty/bell.ll
@@ -1,0 +1,36 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+
+@tag_ret = internal constant [4 x i8] c"ret\00"
+@tag_discarded = internal constant [10 x i8] c"discarded\00"
+
+define i64 @kernel_0() #0 {
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__h__body(ptr null)
+  call void @__quantum__qis__cx__body(ptr null, ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+  call void @__quantum__rt__tuple_record_output(i64 2, ptr @tag_ret)
+  call void @__quantum__rt__result_record_output(ptr null, ptr null)
+  call void @__quantum__rt__result_record_output(ptr inttoptr (i64 1 to ptr), ptr null)
+  call void @__quantum__rt__tuple_record_output(i64 0, ptr @tag_discarded)
+  ret i64 0
+}
+
+declare void @__quantum__qis__h__body(ptr)
+
+declare void @__quantum__qis__cx__body(ptr, ptr)
+
+declare void @__quantum__rt__initialize(ptr)
+
+declare void @__quantum__qis__mz__body(ptr, ptr)
+
+declare void @__quantum__rt__tuple_record_output(i64, ptr)
+
+declare void @__quantum__rt__result_record_output(ptr, ptr)
+
+attributes #0 = { "entry_point" "output_labeling_schema"="qwerty_v1" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="2" }
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}


### PR DESCRIPTION
...as well as adding a `qwerty` version of `bell.ll`, and applying a cosmetic clean up of the --help output. For example, `--group-tuples` only works for qwertified QIR (after Austin added his runtime).