### PR TITLE
Restore missing CLI flags

### DIFF
--- a/app/qir-xacc.cc
+++ b/app/qir-xacc.cc
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
     int num_shots{1024};
     std::string accel_name;
     std::string filename;
-    bool print_accelbuf{true};
+    bool no_print_accelbuf{false};
     bool group_tuples{false};
 
     CLI::App app;
@@ -80,18 +80,18 @@ int main(int argc, char* argv[])
     auto* nshot_opt
         = app.add_option("-s,--shots", num_shots, "Number of shots");
     nshot_opt->capture_default_str();
-    app.add_flag("--print-accelbuf,!--no-print-accelbuf",
-                 print_accelbuf,
-                 "Print XACC AcceleratorBuffer");
-    app.add_flag("--group-tuples,!--no-group-tuples",
+    app.add_flag("--no-print-xacc-accelbuf",
+                 no_print_accelbuf,
+                 "Do not print XACC AcceleratorBuffer");
+    app.add_flag("--group-tuples",
                  group_tuples,
-                 "Print per-tuple measurement statistics rather than "
-                 "per-qubit");
+                 "Print per-tuple/per-array measurement statistics rather "
+                 "than per-qubit");
 
     CLI11_PARSE(app, argc, argv);
 
     qiree::app::run(
-        filename, accel_name, num_shots, print_accelbuf, group_tuples);
+        filename, accel_name, num_shots, !no_print_accelbuf, group_tuples);
 
     return EXIT_SUCCESS;
 }

--- a/app/qir-xacc.cc
+++ b/app/qir-xacc.cc
@@ -80,6 +80,13 @@ int main(int argc, char* argv[])
     auto* nshot_opt
         = app.add_option("-s,--shots", num_shots, "Number of shots");
     nshot_opt->capture_default_str();
+    app.add_flag("--print-accelbuf,!--no-print-accelbuf",
+                 print_accelbuf,
+                 "Print XACC AcceleratorBuffer");
+    app.add_flag("--group-tuples,!--no-group-tuples",
+                 group_tuples,
+                 "Print per-tuple measurement statistics rather than "
+                 "per-qubit");
 
     CLI11_PARSE(app, argc, argv);
 

--- a/src/qirxacc/XaccTupleRuntime.cc
+++ b/src/qirxacc/XaccTupleRuntime.cc
@@ -68,6 +68,14 @@ void XaccTupleRuntime::tuple_record_output(size_type s, OptionalCString tag)
  */
 void XaccTupleRuntime::result_record_output(Result r, OptionalCString)
 {
+    QIREE_VALIDATE(valid_,
+                   << "result_record_output() called without an accompanying "
+                      "array_record_output/tuple_record_output. (Results "
+                      "cannot be grouped by tuple if they are not inside "
+                      "tuples at all.) Please make sure every "
+                      "result_record_output() in your QIR is preceded by a "
+                      "array_record_output() or tuple_record_output().");
+
     execute_if_needed();
     Qubit q = xacc_.result_to_qubit(r);
     push_result(q);


### PR DESCRIPTION
These flags are missing in this new rebased version of the repository. This code was previously merged. This is useful for testing the tuple-grouping functionality without going all the way through the process of linking with the Qwerty compiler. For example:

    $ bin/qir-xacc -i ../examples/qwerty/ghz5.ll -a qpp --group-tuples --no-print-accelbuf
    tuple ret length 5 distinct results 2
    tuple ret result 00000 count 474
    tuple ret result 11111 count 550
    tuple discarded length 0 distinct results 0

Here's the output of --help:

    $ bin/qir-xacc --help
    Usage: bin/qir-xacc [OPTIONS] input

    Positionals:
      input TEXT REQUIRED         QIR input file

    Options:
      -h,--help                   Print this help message and exit
      -i,--input TEXT REQUIRED    QIR input file
      -a,--accelerator TEXT REQUIRED
                                  Accelerator name
      -s,--shots INT [1024]       Number of shots
      --print-accelbuf,--no-print-accelbuf{false}
                                  Print XACC AcceleratorBuffer
      --group-tuples,--no-group-tuples{false}
                                  Print per-tuple measurement statistics rather than per-qubit

I wish it wouldn't print `{false}`, but I read through the CLI11 source, and I cannot find an easy way to turn that off.