### PR TITLE
Handle null tag in tuple runtime

### DIFF
--- a/src/qirxacc/XaccTupleRuntime.cc
+++ b/src/qirxacc/XaccTupleRuntime.cc
@@ -48,7 +48,7 @@ void XaccTupleRuntime::initialize(OptionalCString env)
 void XaccTupleRuntime::array_record_output(size_type s, OptionalCString tag)
 {
     execute_if_needed();
-    this->start_tracking(GroupingType::array, tag, s);
+    this->start_tracking(GroupingType::array, tag ? tag : "<null>", s);
 }
 
 //---------------------------------------------------------------------------//
@@ -59,7 +59,7 @@ void XaccTupleRuntime::array_record_output(size_type s, OptionalCString tag)
 void XaccTupleRuntime::tuple_record_output(size_type s, OptionalCString tag)
 {
     execute_if_needed();
-    this->start_tracking(GroupingType::tuple, tag, s);
+    this->start_tracking(GroupingType::tuple, tag ? tag : "<null>", s);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Before:

    $ bin/qir-xacc -i ../examples/bv11010.ll -a qpp --group-tuples
    {
        "AcceleratorBuffer": {
            "name": "qreg_0x5619be8eb640",
            "size": 6,
            "Information": {},
            "Measurements": {
                "01011": 1024
            }
        }
    }
    terminate called after throwing an instance of 'std::logic_error'
      what():  basic_string: construction from null is not valid
    Aborted

After:

    $ bin/qir-xacc -i ../examples/bv11010.ll -a qpp --group-tuples
    {
        "AcceleratorBuffer": {
            "name": "qreg_0x55adf34cd640",
            "size": 6,
            "Information": {},
            "Measurements": {
                "01011": 1024
            }
        }
    }
    array <null> length 5 distinct results 1
    array <null> result 01011 count 1024

(Note that `--group-tuples` depends on #14)