### PR TITLE
Allow building static CQiree

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -135,5 +135,8 @@ StatementMacros:
   - QT_REQUIRE_VERSION
 TabWidth:        8
 UseTab:          Never
+---
+Language: Json
+DisableFormat: true
 ...
 # vim: set ft=yaml ts=2 sw=2 :

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   linux:
-    name: ${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}-llvm${{matrix.llvm}}
+    name: ${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}-${{ matrix.shared == 'ON' && 'shared' || 'static' }}-llvm${{matrix.llvm}}
     strategy:
       matrix:
         include:
@@ -18,10 +18,22 @@ jobs:
             compiler: gcc
             version: 12
             llvm: 14
+            shared: ON
+          - runner: jammy
+            compiler: gcc
+            version: 12
+            llvm: 14
+            shared: OFF
           - runner: jammy
             compiler: clang
             version: 15
             llvm: 15
+            shared: ON
+          - runner: jammy
+            compiler: clang
+            version: 15
+            llvm: 15
+            shared: OFF
     runs-on: >-
       ${{  matrix.runner == 'focal' && 'ubuntu-20.04'
         || matrix.runner == 'jammy' && 'ubuntu-22.04'
@@ -67,6 +79,7 @@ jobs:
             -DQIREE_BUILD_TESTS:BOOL=ON \
             -DQIREE_DEBUG:BOOL=ON \
             -DQIREE_USE_XACC:BOOL=OFF \
+            -DQIREE_SHARED_LIBS:BOOL=${{ matrix.shared }} \
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_INSTALL_PREFIX="${{github.workspace}}/install" \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   linux:
-    name: ${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}-${{ matrix.shared == 'ON' && 'shared' || 'static' }}-llvm${{matrix.llvm}}
+    name: ${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}-${{ matrix.shared && 'shared' || 'static' }}-llvm${{matrix.llvm}}
     strategy:
       matrix:
         include:
@@ -18,22 +18,17 @@ jobs:
             compiler: gcc
             version: 12
             llvm: 14
-            shared: ON
+            shared: true
           - runner: jammy
             compiler: gcc
             version: 12
             llvm: 14
-            shared: OFF
+            shared: false
           - runner: jammy
             compiler: clang
             version: 15
             llvm: 15
-            shared: ON
-          - runner: jammy
-            compiler: clang
-            version: 15
-            llvm: 15
-            shared: OFF
+            shared: true
     runs-on: >-
       ${{  matrix.runner == 'focal' && 'ubuntu-20.04'
         || matrix.runner == 'jammy' && 'ubuntu-22.04'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ repos:
     - id: check-shebang-scripts-are-executable
     - id: check-json
     - id: check-yaml
+      # .clang-format contains multiple documents for different languages
+      args: ['--allow-multiple-documents']
     - id: end-of-file-fixer
       exclude: '\.(diff|patch)$'
     - id: trailing-whitespace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,8 @@ set(QIREE_RUNTIME_OUTPUT_DIRECTORY
 enable_language(C) # Needed for LLVM
 find_package(LLVM REQUIRED)
 if((LLVM_VERSION VERSION_LESS 14)
-  OR (LLVM_VERSION VERSION_GREATER_EQUAL 21))
-  message(WARNING "QIR-EE is only tested with LLVM 14-20: found version ${LLVM_VERSION}")
+  OR (LLVM_VERSION VERSION_GREATER_EQUAL 22))
+  message(WARNING "QIR-EE is only tested with LLVM 14-21: found version ${LLVM_VERSION}")
 endif()
 
 if(QIREE_USE_QSIM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ option(QIREE_BUILD_TESTS "Build QIR-EE unit tests" ON)
 option(QIREE_BUILD_EXAMPLES "Build QIR-EE examples" OFF)
 option(QIREE_USE_QSIM "Download and build Google qsim backend" OFF)
 option(QIREE_USE_XACC "Build XACC interface" ON)
-option(QIREE_SHARED_LIBS "Build shared libraries, not static libraries" ON)
 
 qiree_set_default(BUILD_TESTING ${QIREE_BUILD_TESTS})
 
@@ -78,10 +77,10 @@ qiree_set_default(CMAKE_CXX_EXTENSIONS OFF)
 
 ### Linking flags ###
 # Default to building shared libraries (*not* a cache variable)
-qiree_set_default(BUILD_SHARED_LIBS ${QIREE_SHARED_LIBS})
+qiree_set_default(BUILD_SHARED_LIBS ON)
 # Inform installed binaries of external library rpaths
 qiree_set_default(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
-if(QIREE_SHARED_LIBS)
+if(BUILD_SHARED_LIBS)
   # Inform installed binaries of internal library rpaths
   qiree_set_default(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
   # Do not relink libs/binaries when dependent shared libs change

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(QIREE_BUILD_TESTS "Build QIR-EE unit tests" ON)
 option(QIREE_BUILD_EXAMPLES "Build QIR-EE examples" OFF)
 option(QIREE_USE_QSIM "Download and build Google qsim backend" OFF)
 option(QIREE_USE_XACC "Build XACC interface" ON)
+option(QIREE_SHARED_LIBS "Build shared libraries, not static libraries" ON)
 
 qiree_set_default(BUILD_TESTING ${QIREE_BUILD_TESTS})
 
@@ -77,10 +78,10 @@ qiree_set_default(CMAKE_CXX_EXTENSIONS OFF)
 
 ### Linking flags ###
 # Default to building shared libraries (*not* a cache variable)
-qiree_set_default(BUILD_SHARED_LIBS ON)
+qiree_set_default(BUILD_SHARED_LIBS ${QIREE_SHARED_LIBS})
 # Inform installed binaries of external library rpaths
 qiree_set_default(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
-if(BUILD_SHARED_LIBS)
+if(QIREE_SHARED_LIBS)
   # Inform installed binaries of internal library rpaths
   qiree_set_default(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
   # Do not relink libs/binaries when dependent shared libs change

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,10 +13,6 @@
             "binaryDir": "${sourceDir}/build-${presetName}",
             "generator": "Ninja",
             "cacheVariables": {
-                "BUILD_SHARED_LIBS": {
-                    "type": "BOOL",
-                    "value": "ON"
-                },
                 "CMAKE_BUILD_TYPE": {
                     "type": "STRING",
                     "value": "Debug"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ doc` (user) or `make doxygen` (developer).
 
 There are two dependencies for QIR-EE to work properly. Please make sure to
 download and install the most current versions of:
-1. [LLVM](https://releases.llvm.org/) (we have tested versions 14 through 18)
+1. [LLVM](https://releases.llvm.org/) (we have tested versions 14 through 21)
 2. [XACC](https://github.com/ORNL-QCI/xacc) (repo that is actively
    maintained -- not the eclipse one; currently required for execution in
    this version of qir-ee; we recommend setting option `-DQIREE_MINIMAL_BUILD=ON`

--- a/src/cqiree/CMakeLists.txt
+++ b/src/cqiree/CMakeLists.txt
@@ -28,10 +28,10 @@ target_link_libraries(cqiree
 #----------------------------------------------------------------------------#
 
 # C/C++ source headers
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/cqiree"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/cqiree"
   COMPONENT development
-  FILES_MATCHING REGEX ".*\\.hh$"
+  FILES_MATCHING REGEX ".*\\.hh?$"
 )
 
 #-----------------------------------------------------------------------------#

--- a/src/cqiree/CMakeLists.txt
+++ b/src/cqiree/CMakeLists.txt
@@ -12,7 +12,7 @@ if(QIREE_USE_QSIM)
   list(APPEND _CQIREE_LIBS QIREE::qirqsim)
 endif()
 
-qiree_add_library(cqiree MODULE
+qiree_add_library(cqiree
   CQiree.cc
   QireeManager.cc
 )

--- a/src/cqiree/CMakeLists.txt
+++ b/src/cqiree/CMakeLists.txt
@@ -12,7 +12,15 @@ if(QIREE_USE_QSIM)
   list(APPEND _CQIREE_LIBS QIREE::qirqsim)
 endif()
 
-qiree_add_library(cqiree
+if(QIREE_SHARED_LIBS)
+    # When building with shared libs, this should be a shared library that can
+    # be dlopen()'d.
+    set(_LIB_TYPE MODULE)
+else()
+    set(_LIB_TYPE)
+endif()
+
+qiree_add_library(cqiree ${_LIB_TYPE}
   CQiree.cc
   QireeManager.cc
 )

--- a/src/cqiree/CMakeLists.txt
+++ b/src/cqiree/CMakeLists.txt
@@ -12,12 +12,12 @@ if(QIREE_USE_QSIM)
   list(APPEND _CQIREE_LIBS QIREE::qirqsim)
 endif()
 
-if(QIREE_SHARED_LIBS)
-    # When building with shared libs, this should be a shared library that can
-    # be dlopen()'d.
-    set(_LIB_TYPE MODULE)
+if(BUILD_SHARED_LIBS)
+  # When building with shared libs, this should be a shared library that can
+  # be dlopen()'d.
+  set(_LIB_TYPE MODULE)
 else()
-    set(_LIB_TYPE)
+  set(_LIB_TYPE)
 endif()
 
 qiree_add_library(cqiree ${_LIB_TYPE}
@@ -39,7 +39,7 @@ target_link_libraries(cqiree
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/cqiree"
   COMPONENT development
-  FILES_MATCHING REGEX ".*\\.hh?$"
+  FILES_MATCHING REGEX ".*\\.h$"
 )
 
 #-----------------------------------------------------------------------------#

--- a/src/cqiree/CQiree.h
+++ b/src/cqiree/CQiree.h
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <cstdint>
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/cqiree/CQiree.h
+++ b/src/cqiree/CQiree.h
@@ -7,12 +7,12 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stddef.h>
-#include <stdint.h>
 
 /* Opaque pointer to QireeManager */
 typedef struct CQiree_s CQiree;

--- a/src/qiree_config.h.in
+++ b/src/qiree_config.h.in
@@ -12,5 +12,6 @@
 #cmakedefine01 QIREE_DEBUG
 #cmakedefine01 QIREE_USE_QSIM
 #cmakedefine01 QIREE_USE_XACC
+#cmakedefine01 QIREE_SHARED_LIBS
 
 #endif /* qiree_config_h */

--- a/src/qiree_config.h.in
+++ b/src/qiree_config.h.in
@@ -12,6 +12,5 @@
 #cmakedefine01 QIREE_DEBUG
 #cmakedefine01 QIREE_USE_QSIM
 #cmakedefine01 QIREE_USE_XACC
-#cmakedefine01 QIREE_SHARED_LIBS
 
 #endif /* qiree_config_h */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,12 +69,12 @@ qiree_add_test(qiree ResultDistribution)
 #---------------------------------------------------------------------------##
 
 qiree_add_test(cqiree CQiree)
-if(QIREE_SHARED_LIBS)
-    # Tester uses dlopen()
-    add_dependencies(cqiree_CQireeTest cqiree)
+if(BUILD_SHARED_LIBS)
+  # Tester uses dlopen()
+  add_dependencies(cqiree_CQireeTest cqiree)
 else()
-    # Statically link tester with cqiree
-    target_link_libraries(cqiree_CQireeTest cqiree)
+  # Statically link tester with cqiree
+  target_link_libraries(cqiree_CQireeTest cqiree)
 endif()
 
 #---------------------------------------------------------------------------##

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,7 +69,13 @@ qiree_add_test(qiree ResultDistribution)
 #---------------------------------------------------------------------------##
 
 qiree_add_test(cqiree CQiree)
-add_dependencies(cqiree_CQireeTest cqiree)
+if(QIREE_SHARED_LIBS)
+    # Tester uses dlopen()
+    add_dependencies(cqiree_CQireeTest cqiree)
+else()
+    # Statically link tester with cqiree
+    target_link_libraries(cqiree_CQireeTest cqiree)
+endif()
 
 #---------------------------------------------------------------------------##
 # QIRXACC TESTS

--- a/test/cqiree/CQiree.test.cc
+++ b/test/cqiree/CQiree.test.cc
@@ -17,6 +17,7 @@
 
 #include "qiree_config.h"
 #include "qiree_targets.h"
+#include "qiree_test_config.h"
 
 #include "qiree/Assert.hh"
 #include "qiree_test.hh"
@@ -45,13 +46,13 @@ class CQireeTest : public ::qiree::test::Test
   protected:
     void SetUp() override
     {
-#if QIREE_SHARED_LIBS
+#if BUILD_SHARED_LIBS
         lib_handle_ = dlopen(cqiree_library_path, RTLD_LAZY);
         ASSERT_NE(lib_handle_, nullptr)
             << "Failed to load libcqiree: " << dlerror();
 #endif
 
-#if QIREE_SHARED_LIBS
+#if BUILD_SHARED_LIBS
 #    define LOAD_FUNCPTR(FUNC)                           \
         FUNC##_fn_ = reinterpret_cast<qiree_##FUNC##_t>( \
             dlsym(lib_handle_, "qiree_" #FUNC));         \

--- a/test/cqiree/CQiree.test.cc
+++ b/test/cqiree/CQiree.test.cc
@@ -15,6 +15,7 @@
 #include <vector>
 #include <dlfcn.h>
 
+#include "qiree_config.h"
 #include "qiree_targets.h"
 
 #include "qiree/Assert.hh"
@@ -44,15 +45,21 @@ class CQireeTest : public ::qiree::test::Test
   protected:
     void SetUp() override
     {
+#if QIREE_SHARED_LIBS
         lib_handle_ = dlopen(cqiree_library_path, RTLD_LAZY);
         ASSERT_NE(lib_handle_, nullptr)
             << "Failed to load libcqiree: " << dlerror();
+#endif
 
-#define LOAD_FUNCPTR(FUNC)                           \
-    FUNC##_fn_ = reinterpret_cast<qiree_##FUNC##_t>( \
-        dlsym(lib_handle_, "qiree_" #FUNC));         \
-    ASSERT_NE(FUNC##_fn_, nullptr)                   \
-        << "Failed to load " << #FUNC << ": " << dlerror();
+#if QIREE_SHARED_LIBS
+#    define LOAD_FUNCPTR(FUNC)                           \
+        FUNC##_fn_ = reinterpret_cast<qiree_##FUNC##_t>( \
+            dlsym(lib_handle_, "qiree_" #FUNC));         \
+        ASSERT_NE(FUNC##_fn_, nullptr)                   \
+            << "Failed to load " << #FUNC << ": " << dlerror();
+#else
+#    define LOAD_FUNCPTR(FUNC) FUNC##_fn_ = qiree_##FUNC;
+#endif
         LOAD_FUNCPTR(create);
         LOAD_FUNCPTR(load_module_from_memory);
         LOAD_FUNCPTR(load_module_from_file);

--- a/test/cqiree/CQiree.test.cc
+++ b/test/cqiree/CQiree.test.cc
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #include "cqiree/CQiree.h"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <fstream>

--- a/test/qiree_test_config.h.in
+++ b/test/qiree_test_config.h.in
@@ -9,6 +9,8 @@
 #ifndef qiree_test_config_h
 #define qiree_test_config_h
 
+#cmakedefine01 BUILD_SHARED_LIBS
+
 static char const qiree_source_dir[] = "@QIREE_SOURCE_DIR@";
 
 #endif /* qiree_test_config_h */


### PR DESCRIPTION
With these changes, the compilation flow I need in the Qwerty compiler works. That is, I can create a [`qiree_sys` crate][1] that [builds a static QIR-EE][2] and provides Rust bindings, call QIR-EE from Rust code, and link the whole thing into a Python extension module (a self-contained shared library).

I think this PR is easiest reviewed commit-by-commit. I tried to leave an explanation of each change in each commit.

#### Testing

The unit tests pass and `bin/qir-qsim ../examples/bv11010.ll` runs successfully. (Note that I built only with `-DQIREE_USE_QSIM=ON -DQIREE_USE_XACC=OFF`, though.)

I can also [call `qiree_create()` and `qiree_destroy()` from inside the Qwerty runtime][3] without any obvious explosions.

[1]: https://github.com/gt-tinker/qwerty/tree/70b2075ce699155408c9b228cc03d4ab265f1f9c/qiree_sys
[2]: https://github.com/gt-tinker/qwerty/blob/70b2075ce699155408c9b228cc03d4ab265f1f9c/qiree_sys/build.rs#L52-L67
[3]: https://github.com/gt-tinker/qwerty/blob/70b2075ce699155408c9b228cc03d4ab265f1f9c/qwerty_ast_to_mlir/src/run/backend/qiree.rs#L9-L12